### PR TITLE
Change max-height of .actionSheetScroller to vh

### DIFF
--- a/actionsheet/actionsheet.css
+++ b/actionsheet/actionsheet.css
@@ -32,7 +32,7 @@
 }
 
 .actionSheetScroller {
-    max-height: 60%;
+    max-height: 60vh;
     overflow-x: hidden;
     overflow-y: auto;
     /* Override default style being applied by polymer */


### PR DESCRIPTION
60% does not work for quality selector as it results in it extending offscreen without allowing scrolling.
Using 60vh fixes the issue for the playback quality selector.

However I am unsure if this change would have any implications for other uses of the same class.
