### PR TITLE
Fix iOS download

### DIFF
--- a/multidownload.js
+++ b/multidownload.js
@@ -48,7 +48,7 @@ define(['browser'], function (browser) {
             throw new Error('`urls` required');
         }
 
-        if (typeof document.createElement('a').download === 'undefined') {
+        if (!browser.iOS && typeof document.createElement('a').download === 'undefined') {
             return fallback(urls);
         }
 


### PR DESCRIPTION
This fixes iOS downloads for me, that is, before this change selecting "Download" from the context menu would not trigger the download in any iOS browser.

Unfortunately the download only succeeds in Safari Mobile. 

Even using the download URL directly wont work in any browser other than Safari. It is as if other browsers are not aware of the file type and without knowing which application could handle the file beforehand, the download is refused. Checking the response headers, Content-Type is correctly set to the MIME type. The logs show a GET request that is cancelled in short order, and then a HEAD request to the same download URL which is not handled by the server.