### PR TITLE
don't hide media controls if there is a next item

### DIFF
--- a/playback/mediasession.js
+++ b/playback/mediasession.js
@@ -170,7 +170,9 @@
 
         var player = this;
 
-        hideMediaControls();
+        if (!state.NextItem) {
+            hideMediaControls();
+        }
     }
 
     function releaseCurrentPlayer() {


### PR DESCRIPTION
Fixes an issue on ios where lock screen controls disappear between songs