### PR TITLE
fix scrolling on iOS while moving list items

### DIFF
--- a/emby-itemscontainer/emby-itemscontainer.js
+++ b/emby-itemscontainer/emby-itemscontainer.js
@@ -161,6 +161,17 @@
                     return onDrop(evt, self);
                 }
             });
+
+            // Fix for https://github.com/SortableJS/Sortable/issues/1319
+            if (browser.iOS) {
+                self.sortable.el.addEventListener('touchstart', function(e) {
+
+                    let element = e.target;
+                    if (element && element.matches(".listViewDragHandle")) {
+                        e.preventDefault();
+                    }
+                });
+            }
         });
     };
 


### PR DESCRIPTION
When trying to move items in a list on iOS the page is scrolled along with the draggable item.

See https://github.com/SortableJS/Sortable/issues/1319 